### PR TITLE
Create 3 dependency pages, and update new_dev_guide

### DIFF
--- a/docs/devsguide/linuxdep.rst
+++ b/docs/devsguide/linuxdep.rst
@@ -1,0 +1,361 @@
+.. _linuxdep:
+
+===========================
+Linux Dependencies for PyNE
+===========================
+
+Something to note before you begin the installation process is the version of Python 
+that you are using. PyNE is currently supported from Python 2 through Python 3.6 
+(NOT 3.7, which is coming in future updates).
+
+
+-------------
+PyNE Library:
+-------------
+
+PyNE is what is known as a library in Python (as with many languages, 
+libraries can be built and installed to add functionalities to the language), 
+and it is designed to assist in Nuclear Engineering projects. 
+
+
+Python
+''''''
+
+Python is a popular computer language for building applications, 
+data science, and visualization. 
+
+``To Install:``
+
+Anaconda is a comprehensive Python package 
+which provides a free installation for MacOS, Windows, and Linux. Follow the instructions 
+for your device's platform `here <https://docs.anaconda.com/anaconda/install/>`_ if you would 
+like to use Anaconda. Installing Python through Anaconda will result in many of the packages and 
+dependencies for PyNE being satisfied.
+
+If you want to download Python without the rest of Anaconda, use 
+the links in the resources below. Keep in-mind that PyNE is currently 
+not supported on Python 3.7 or later, but you can follow the instructions
+for Anaconda users in the New Developer's Guide.
+
+``Resources:``
+
+#. `Python Download (Not Anaconda) <https://www.python.org/downloads/>`_
+#. `Python Wiki <https://wiki.python.org/moin/>`_
+#. `Beginner’s Guide <https://wiki.python.org/moin/BeginnersGuide>`_
+
+
+GCC
+'''
+
+GCC stands for GNU Compiler Collection, and GNU is a Unix-Like operating system 
+that allocates resources and communicates with hardware. GNU is often used with 
+a kernel called Linux. The Compiler Collection is one element that allows for 
+PyNE to work as a Python library, even though it is built with several languages.
+
+``To Install:``
+
+To download GCC, visit `Installing GCC <https://gcc.gnu.org/install/index.html>`_
+
+``Resources:``
+
+#. `Documentation <https://gcc.gnu.org/onlinedocs/gfortran/#toc-Compiler-Characteristics-1>`_
+#. `GCC FAQ <https://gcc.gnu.org/wiki/FAQ>`_
+#. `GCC Glossary <https://gcc.gnu.org/wiki/GCC_glossary>`_
+
+
+CMake
+'''''
+
+CMake is designed to build, test, and compile packages programs across platforms.
+
+``To Install:``
+
+To download CMake, visit `Downloads <https://cmake.org/download/>`_.
+
+``Resources:``
+
+#. `Wiki <https://gitlab.kitware.com/cmake/community/-/wikis/home>`_
+#. `Tutorial <https://cmake.org/cmake/help/latest/guide/tutorial/index.html>`_
+
+
+Numpy
+'''''
+
+Numpy is a library in Python that adds support to matrices and arrays, 
+as well as mathematical functions acting on those arrays.
+
+``To Install:``
+
+#. Update the packages index ::
+	
+	$ sudo apt update
+
+#. Install with sudo apt ::
+
+    $ sudo apt-get install python-numpy
+
+For more details, go `here <https://phoenixnap.com/kb/install-numpy>`_
+
+If you'd like to use Pip to install numpy, go 
+`here for Debian <https://phoenixnap.com/kb/how-to-install-pip-on-debian-9>`_ and 
+`here for Ubuntu <https://phoenixnap.com/kb/how-to-install-pip-on-ubuntu>`_ .
+
+``Resources:``
+
+#. `Tutorial <https://numpy.org/learn/>`_
+#. `Documentation <https://numpy.org/doc/stable/>`_
+
+
+SciPy
+'''''
+
+SciPy is a Python library that adds functions for linear algebra, optimization, 
+integration, and other scientific or engineering tasks.
+
+``To Install:``
+
+Install using sudo apt-get ::
+
+    $ sudo apt-get install python-scipy
+
+For more details, go `here <https://www.scipy.org/install.html>`_
+
+``Resources:``
+
+#. `Getting Started <https://www.scipy.org/getting-started.html>`_
+#. `Tutorial <https://docs.scipy.org/doc/scipy/reference/tutorial/index.html>`_
+#. `Documentation <https://www.scipy.org/docs.html>`_
+
+
+Cython
+''''''
+
+Cython is a compiler that helps in making C or C++ extensions for python.
+
+``To Install:``
+
+Install using sudo apt-get ::
+
+    $ sudo apt-get install -y cython
+
+For more details, go `here <https://cython.readthedocs.io/en/latest/src/quickstart/install.html>`_ .
+
+``Resources:``
+
+#. `Wiki <https://github.com/cython/cython/wiki>`_
+#. `User's Guide <https://cython.readthedocs.io/en/latest/src/userguide/index.html>`_
+#. `Cython <https://cython.org>`_
+
+
+HDF5
+''''
+
+HDF5 (the Hierarchical Data Format version 5) is a format that supports large, 
+complex data in a file directory like structure similar to how you might with your computer.
+
+``To Install:``
+
+Follow the instructions `here <http://depts.washington.edu/cssuwb/wiki/linux_hdf5_installation>`_
+to install HDF5.
+
+Alternatively, based off of instructions found `here <https://medium.com/@jupyterdata/installing-hdf5-pytables-on-ubuntu-f4808f515f2e>`_ 
+, enter::
+
+    $ sudo apt-get install libhdf5-serial-dev
+
+To install from source code, 
+follow the instructions `here <https://www.hdfgroup.org/downloads/hdf5/source-code/>`_ .
+
+``Resources:``
+
+#. `Examples <https://portal.hdfgroup.org/display/HDF5/HDF5+Examples>`_
+#. `Learning HDF5 <https://portal.hdfgroup.org/display/HDF5/Learning+HDF5>`_
+#. `Known Problems <https://portal.hdfgroup.org/display/support/HDF5%201.12.0#knownprob>`_
+
+
+PyTables
+''''''''
+
+PyTables is a package for managing large hierarchical datasets.
+
+``To Install:``
+
+For a variety of installation instructions, 
+follow the instructions `here <http://www.pytables.org/usersguide/installation.html>`_ .
+
+Alternatively, based off of instructions found `here <https://medium.com/@jupyterdata/installing-hdf5-pytables-on-ubuntu-f4808f515f2e>`_ 
+, enter ::
+
+    $ sudo apt-get install python-tables
+
+``Resources:``
+
+#. `FAQ <http://www.pytables.org/FAQ.html>`_
+#. `Tutorial <http://www.pytables.org/usersguide/tutorials.html>`_
+#. `Project Pointers <http://www.pytables.org/project_pointers.html>`_
+
+
+BLAS
+''''
+
+BLAS (Basic Linear Algebra Subroutines) coordinates operations on vectors and matrices.
+
+``To Install:``
+
+Follow the instructions `here <https://ahmadzareei.github.io/azareei/linux/2016/04/08/configuring-blas-lapack.html>`_
+
+Installation methods can be found `here <http://www.netlib.org/blas/#_software>`_
+
+``Resources:``
+
+#. `Documentation <http://www.netlib.org/blas/#_documentation>`_
+
+
+LAPACK
+''''''
+
+LAPACK (Liner Algebra Package) is a software library for numerical liner algebra.
+
+``To Install:``
+
+Follow the instructions `here <https://ahmadzareei.github.io/azareei/linux/2016/04/08/configuring-blas-lapack.html>`_
+
+Installation methods can be found `here <http://www.netlib.org/lapack/#_software>`_
+
+Alternatively, based off of instructions found `here <https://coral.ise.lehigh.edu/jild13/2016/07/27/install-lapack-and-blas-on-linux-based-systems/>`_ ,
+do the following:
+
+#. Download `LAPack <http://www.netlib.org/lapack/>`_
+
+#. Go to the LAPACK directory and enter ::
+
+    $ make
+
+#. Now you have created a library called “lapack_MACOS.a”, enter ::
+
+    $ sudo cp liblapack.a /usr/local/lib/
+
+``Resources:``
+
+#. `FAQ <http://www.netlib.org/lapack/faq.html>`_
+#. `User's Guide <http://www.netlib.org/lapack/lug/>`_
+
+
+Numexpr
+'''''''
+
+Numexpr is a fast numerical evaluation tool for numpy, ensuring that 
+expressions operating on arrays are faster and take up less memory.
+
+``To Install:``
+
+Based off of instructions found `here <https://howtoinstall.co/en/ubuntu/trusty/python-numexpr>`_
+, enter ::
+
+    $ sudo apt-get install python-numexpr
+
+``Resources:``
+
+#. `PyPi Project Homepage <https://pypi.org/project/numexpr/>`_
+#. `Github Repository <https://github.com/pydata/numexpr>`_
+
+
+--------
+Website:
+--------
+
+Sphinx
+''''''
+
+A python based documentation generator that allows files to be written into HTML, LaTeX, 
+ePub, Texinfo, pages, and plain text. Sphinx uses reStructuredText, which is a very 
+straight-forward markup language.
+
+``To Install:``
+
+Based off of the instructions found `here <https://www.sphinx-doc.org/en/1.6/install.html#debian-ubuntu-install-sphinx-using-packaging-system>`_
+, enter ::
+
+    $ apt-get install python-sphinx
+
+``Resources:``
+
+#. `Sphinx <https://www.sphinx-doc.org/en/master/>`_
+#. `Tutorial <http://matplotlib.sourceforge.net/sampledoc/>`_
+#. `reStructuredText Cheat Sheet <https://docutils.sourceforge.io/docs/user/rst/cheatsheet.txt>`_
+
+
+Sphinxcontrib-bibtex
+''''''''''''''''''''
+
+An extension allowing Sphinx to interact with BibTeX.
+
+``To Install:``
+
+Open your command line and enter ::
+
+    $ sudo apt-get install -y python3-sphinxcontrib.bibtex
+
+``Resources:``
+
+#. `Documentation <https://sphinxcontrib-bibtex.readthedocs.io/en/latest/>`_ 
+#. `Known Issues and Workarounds <https://sphinxcontrib-bibtex.readthedocs.io/en/latest/usage.html#known-issues-and-workarounds>`_
+#. `Example <https://sphinxcontrib-bibtex.readthedocs.io/en/latest/quickstart.html#minimal-example>`_
+
+
+PrettyTable
+'''''''''''
+
+PrettyTable is a python library that adds a lot of versatility to table creation.
+
+``To Install:``
+
+Open your command line and enter ::
+
+    $ sudo apt-get install -y python-prettytable
+
+``Resources:``
+
+#. `Tutorial <https://code.google.com/archive/p/prettytable/wikis/Tutorial.wiki>`_
+
+
+Cloud Sphinx
+''''''''''''
+
+Cloud is a Sphinx theme that PyNE uses to generate its 
+HTML documentation (like this site).
+
+``To Install:``
+
+#. Download the `source code <https://pypi.org/project/cloud_sptheme/>`_ .
+
+#. Un-zip the file (if necessary) and, in the command line, "cd" into the folder.
+
+#. Enter ::
+
+    $ python setup.py install
+
+For more details about installing on windows with a setup.py file, go 
+`here <https://docs.python.org/2/install/#standard-build-and-install>`_ .
+
+``Resources:``
+
+#. `Documentation <https://cloud-sptheme.readthedocs.io/en/latest/>`_
+#. `Source <https://foss.heptapod.net/doc-utils/cloud_sptheme>`_
+
+
+Jupyter
+'''''''
+
+If you have downloaded Python through Anaconda Jupyter requirements should 
+be satisfied, but it never hurts to make sure. 
+
+
+``To Install:``
+
+To download Jupyter Notebook, visit `Installing Jupyter-Notebook <https://jupyter.readthedocs.io/en/latest/install.html>`_ .
+
+``Resources:``
+
+#. `Additional Installation Information <https://jupyter.readthedocs.io/en/latest/install.html>`_
+#. `Project Documentation <https://jupyter.readthedocs.io/en/latest/projects/doc-proj-categories.html#deployment>`_

--- a/docs/devsguide/macosdep.rst
+++ b/docs/devsguide/macosdep.rst
@@ -1,0 +1,352 @@
+.. _macosdep:
+
+===========================
+MacOS Dependencies for PyNE
+===========================
+
+Something to note before you begin the installation process is the version of Python 
+that you are using. PyNE is currently supported from Python 2 through Python 3.6 
+(NOT 3.7, which is coming in future updates).
+
+
+-------------
+PyNE Library:
+-------------
+
+PyNE is what is known as a library in Python (as with many languages, 
+libraries can be built and installed to add functionalities to the language), 
+and it is designed to assist in Nuclear Engineering projects. 
+
+
+Python
+''''''
+
+Python is a popular computer language for building applications, 
+data science, and visualization. 
+
+``To Install:``
+
+Anaconda is a comprehensive Python package 
+which provides a free installation for MacOS, Windows, and Linux. Follow the instructions 
+for your device's platform `here <https://docs.anaconda.com/anaconda/install/>`_ if you would 
+like to use Anaconda. Installing Python through Anaconda will result in many of the packages and 
+dependencies for PyNE being satisfied.
+
+If you want to download Python without the rest of Anaconda, use 
+the links in the resources below. Keep in-mind that PyNE is currently 
+not supported on Python 3.7 or later, but you can follow the instructions
+for Anaconda users in the New Developer's Guide.
+
+``Resources:``
+
+#. `Python Download (Not Anaconda) <https://www.python.org/downloads/>`_
+#. `Python Wiki <https://wiki.python.org/moin/>`_
+#. `Beginner’s Guide <https://wiki.python.org/moin/BeginnersGuide>`_
+
+
+GCC
+'''
+
+GCC stands for GNU Compiler Collection, and GNU is a Unix-Like operating system 
+that allocates resources and communicates with hardware. GNU is often used with 
+a kernel called Linux. The Compiler Collection is one element that allows for 
+PyNE to work as a Python library, even though it is built with several languages.
+
+``To Install:``
+
+`Installing GCC <https://gcc.gnu.org/install/index.html>`_
+
+If you have homebrew installed on your device, you can install GCC by entering ::
+
+	$ brew install gcc
+
+``Resources:``
+
+#. `Documentation <https://gcc.gnu.org/onlinedocs/gfortran/#toc-Compiler-Characteristics-1>`_
+#. `GCC FAQ <https://gcc.gnu.org/wiki/FAQ>`_
+#. `GCC Glossary <https://gcc.gnu.org/wiki/GCC_glossary>`_
+
+
+CMake
+'''''
+
+CMake is designed to build, test, and compile packages programs across platforms.
+
+``To Install:``
+
+To download CMake, you can visit `Downloads <https://cmake.org/download/>`_.
+
+If you have homebrew installed on your device, you can install GCC by entering ::
+
+	$ brew install gcc
+
+``Resources:``
+
+#. `Wiki <https://gitlab.kitware.com/cmake/community/-/wikis/home>`_
+#. `Tutorial <https://cmake.org/cmake/help/latest/guide/tutorial/index.html>`_
+
+
+Numpy
+'''''
+
+Numpy is a library in Python that adds support to matrices and arrays, 
+as well as mathematical functions acting on those arrays.
+
+``To Install:``
+
+For the latest version using pip, in the command line enter ::
+
+	$ pip install numpy
+
+For the latest version using Conda, in the command line enter ::
+
+	$ conda install numpy
+
+
+``Resources:``
+
+#. `Tutorial <https://numpy.org/learn/>`_
+#. `Documentation <https://numpy.org/doc/stable/>`_
+
+
+SciPy
+'''''
+
+SciPy is a Python library that adds functions for linear algebra, optimization, 
+integration, and other scientific or engineering tasks.
+
+``To Install:``
+
+`Installation <https://www.scipy.org/install.html>`_
+
+``Resources:``
+
+#. `Getting Started <https://www.scipy.org/getting-started.html>`_
+#. `Tutorial <https://docs.scipy.org/doc/scipy/reference/tutorial/index.html>`_
+#. `Documentation <https://www.scipy.org/docs.html>`_
+
+
+Cython
+''''''
+
+Cython is a compiler that helps in making C or C++ extensions for python.
+
+``To Install:``
+
+For the latest version, in the command line enter ::
+
+	$ pip install cython
+
+If you have homebrew installed on your device, you can install Cython by entering ::
+
+	$ brew install cython
+
+``Resources:``
+
+#. `Wiki <https://github.com/cython/cython/wiki>`_
+#. `User's Guide <https://cython.readthedocs.io/en/latest/src/userguide/index.html>`_
+#. `Cython <https://cython.org>`_
+
+
+HDF5
+''''
+
+HDF5 (the Hierarchical Data Format version 5) is a format that supports large, 
+complex data in a file directory like structure similar to how you might with your computer.
+
+``To Install:``
+
+To install from source code, 
+follow the instructions `here <https://www.hdfgroup.org/downloads/hdf5/source-code/>`_ .
+
+For the latest version, in the command line enter ::
+
+	$ brew install hdf5
+
+``Resources:``
+
+#. `Examples <https://portal.hdfgroup.org/display/HDF5/HDF5+Examples>`_
+#. `Learning HDF5 <https://portal.hdfgroup.org/display/HDF5/Learning+HDF5>`_
+#. `Known Problems <https://portal.hdfgroup.org/display/support/HDF5%201.12.0#knownprob>`_
+
+
+PyTables
+''''''''
+
+PyTables is a package for managing large hierarchical datasets.
+
+``To Install:``
+
+For a variety of installation instructions, 
+follow the instructions `here <http://www.pytables.org/usersguide/installation.html>`_ .
+
+For the latest version, in the command line enter ::
+
+	$ brew install tables
+
+``Resources:``
+
+#. `FAQ <http://www.pytables.org/FAQ.html>`_
+#. `Tutorial <http://www.pytables.org/usersguide/tutorials.html>`_
+#. `Project Pointers <http://www.pytables.org/project_pointers.html>`_
+
+
+LAPACK
+''''''
+
+LAPACK (Liner Algebra Package) is a software library for numerical liner algebra.
+
+``To Install:``
+
+Other installation methods can be found `here <http://www.netlib.org/lapack/#_software>`_
+
+For the latest version, in the command line enter ::
+
+	$ brew install lapack
+
+``Resources:``
+
+#. `FAQ <http://www.netlib.org/lapack/faq.html>`_
+#. `User's Guide <http://www.netlib.org/lapack/lug/>`_
+
+
+BLAS
+''''
+
+BLAS (Basic Linear Algebra Subroutines) coordinates operations on vectors and matrices.
+
+``To Install:``
+
+Other installation methods can be found `here <http://www.netlib.org/blas/#_software>`_
+
+For the latest version, in the command line enter ::
+
+	$ brew install openblas
+
+``Resources:``
+
+#. `Documentation <http://www.netlib.org/blas/#_documentation>`_
+
+
+Numexpr
+'''''''
+
+Numexpr is a fast numerical evaluation tool for numpy, ensuring that 
+expressions operating on arrays are faster and take up less memory.
+
+``To Install:``
+
+For the latest version, in the command line enter ::
+
+	$ pip install numexpr
+
+``Resources:``
+
+#. `PyPi Project Homepage <https://pypi.org/project/numexpr/>`_
+#. `Github Repository <https://github.com/pydata/numexpr>`_
+
+
+--------
+Website:
+--------
+
+Sphinx
+''''''
+
+A python based documentation generator that allows files to be written into HTML, LaTeX, 
+ePub, Texinfo, pages, and plain text. Sphinx uses reStructuredText, which is a very 
+straight-forward markup language.
+
+``To Install:``
+
+For the latest version, in the command line enter ::
+
+	$ pip install sphinx
+
+``Resources:``
+
+#. `Sphinx <https://www.sphinx-doc.org/en/master/>`_
+#. `Tutorial <http://matplotlib.sourceforge.net/sampledoc/>`_
+#. `reStructuredText Cheat Sheet <https://docutils.sourceforge.io/docs/user/rst/cheatsheet.txt>`_
+
+
+Sphinxcontrib-bibtex
+''''''''''''''''''''
+
+An extension allowing Sphinx to interact with BibTeX.
+
+``To Install:``
+
+For the latest version, in the command line enter ::
+
+	$ pip install sphinxcontrib-bibtex
+
+``Resources:``
+
+#. `Documentation <https://sphinxcontrib-bibtex.readthedocs.io/en/latest/>`_ 
+#. `Known Issues and Workarounds <https://sphinxcontrib-bibtex.readthedocs.io/en/latest/usage.html#known-issues-and-workarounds>`_
+#. `Example <https://sphinxcontrib-bibtex.readthedocs.io/en/latest/quickstart.html#minimal-example>`_
+
+
+PrettyTable
+'''''''''''
+
+PrettyTable is a python library that adds a lot of versatility to table creation.
+
+``To Install:``
+
+For the latest version, in the command line enter ::
+
+	$ pip install prettytable
+
+``Resources:``
+
+#. `Tutorial <https://code.google.com/archive/p/prettytable/wikis/Tutorial.wiki>`_
+
+
+Cloud Sphinx
+''''''''''''
+
+Cloud is a Sphinx theme that PyNE uses to generate its 
+HTML documentation (like this site).
+
+``To Install:``
+
+For the latest version, in the command line enter ::
+
+	$ pip install cloud_sptheme
+
+``Resources:``
+
+#. `Documentation <https://cloud-sptheme.readthedocs.io/en/latest/>`_
+#. `Source <https://foss.heptapod.net/doc-utils/cloud_sptheme>`_
+
+
+Jupyter
+'''''''
+
+If you have downloaded Python through Anaconda Jupyter requirements should 
+be satisfied, but it never hurts to make sure. 
+
+You can check there version by entering ::
+
+	$jupyter —-version
+
+``To Install:``
+
+If you are going to use Python 2:
+
+For the latest version, in the command line enter ::
+
+	$ pip install jupyter
+
+If you are going to use Python 3:
+
+For the latest version, in the command line enter ::
+
+	$ pip3 install jupyter
+
+``Resources:``
+
+#. `Additional Installation Information <https://jupyter.readthedocs.io/en/latest/install.html>`_
+#. `Project Documentation <https://jupyter.readthedocs.io/en/latest/projects/doc-proj-categories.html#deployment>`_

--- a/docs/devsguide/new_dev_guide.rst
+++ b/docs/devsguide/new_dev_guide.rst
@@ -29,19 +29,13 @@ installer. An OSX Git installer is maintained and available for download at
 the http://git-scm.com/download/mac. This method will require Homebrew, which
 may not already be on your device.
 
-
-To Install Homebrew
+Installing Homebrew
 ```````````````````
 This method uses Ruby, but there are other methods you can use `here <https://docs.brew.sh/Installation>`_ .
 
-``To Install Ruby:``
+``To Install:``
 
 `Installing Ruby <https://www.ruby-lang.org/en/documentation/installation/>`_
-
-``Resources:``
-
-#. `Learning Ruby <http://rubylearning.com/satishtalim/tutorial.html>`_
-#. `Official FAQ <https://www.ruby-lang.org/en/documentation/faq/>`_
 
 Run the commands ::
 
@@ -75,9 +69,9 @@ $ sudo apt-get install git
 For more options, there are instructions for installing on several different
 Unix flavors on the Git website, at http://git-scm.com/download/linux.
 
---------------------------------
-Connecting Github account to Git
---------------------------------
+------------------------
+Connecting Github to Git
+------------------------
 For more detailed steps go `here 
 <https://help.github.com/categories/bootcamp/>`__.
 
@@ -113,9 +107,20 @@ each dependency. For example, PyNE is currently supported in conda
 install from 2.7.\* - 3.6.*, and attempting to install with a default
 version of 3.7.\* will result in errors. Setting your version to be
 compatible before you begin will help ensure you are successful.
-For a comprehensive list of all the software that PyNE depends on, examine
-:ref:`Dependencies` .
 
+.. _Dependencies:
+------------------
+PyNE Dependencies
+------------------
+
+.. toctree::
+    :maxdepth: 1
+
+    linuxdep
+    macosdep
+    windowsdep
+
+.. _creating_an_environment:
 
 -----------------------
 Creating an Environment
@@ -157,10 +162,10 @@ tasks/manage-environments.html>`__.
 ==========================
 Signing up for list hosts:
 ==========================
-Everyone faces challenges sometimes when writing effective code. Thankfully, the PyNE developers can always be 
-contacted on the list host at pyne-dev@groups.google.com. Another way to get 
-help is by going to https://groups.google.com/forum/#!forum/pyne-users and 
-joining the group to post. 
+Everyone faces challenges sometimes when writing effective code. Thankfully, 
+the PyNE developers can always be contacted on the list host at 
+pyne-dev@groups.google.com. Another way to get help is by going to 
+https://groups.google.com/forum/#!forum/pyne-users and joining the group to post. 
 
 
 ========================
@@ -196,7 +201,7 @@ these steps.
 
 The PyNE files are now ready for your contributions. You can easily contribute 
 by editing the contents of the folders, submitting these changes to your 
-repository, and making a pull request to PyNE through Github’s website. 
+repository, and making a pull request to PyNE through Github. 
 
 
 =============
@@ -246,357 +251,3 @@ if they follow the formatting of other documents in the PyNE repository. As such
 before you create or update a file, it is a good idea to skim through other PyNE 
 documentation to see how they are formatted. Finally, commit these changes to your 
 forked version and submit a pull request. 
-
-.. _Dependencies:
-
-==================
-PyNE Dependencies:
-==================
-
-Something to note before you begin the installation process is the version of Python 
-that you are using. PyNE is currently supported from Python 2 through Python 3.6 
-(NOT 3.7, which is coming in future updates).
-
-
-------------
-PyNE Library
-------------
-
-PyNE is what is known as a library in Python (as with many languages, 
-libraries can be built and installed to add functionalities to the language), 
-and it is designed to assist in Nuclear Engineering projects. 
-
-**Python:**
-
-Python is a popular computer language for building applications, 
-data science, and visualization. 
-
-``To Install:``
-
-A comprehensive Python package is Anaconda 
-which provides a free installation for MacOS, Windows, and Linux. Follow the instructions 
-for your specific platform `here <https://docs.anaconda.com/anaconda/install/>`_ if you would 
-like to use Anaconda. Installing through Anaconda will result in many of the packages and 
-dependencies being satisfied.
-
-If you want to download Python without the rest of Anaconda, use 
-the links in the resources below. Keep in-mind that PyNE is currently 
-not supported on Python 3.7 or later, but you can 
-:ref:`create an environment<Creating an Environment>` following the instructions above
-for Anaconda users.
-
-``Resources:``
-
-#. `Python Download (Not Anaconda) <https://www.python.org/downloads/>`_
-#. `Python Wiki <https://wiki.python.org/moin/>`_
-#. `Beginner’s Guide <https://wiki.python.org/moin/BeginnersGuide>`_
-
-
-**Ruby:**
-
-Ruby is a programming language with a wide array of functionality, and a 
-syntax similar to that of Python.
-
-``To Install:``
-
-`Installing Ruby <https://www.ruby-lang.org/en/documentation/installation/>`_
-
-``Resources:``
-
-#. `Learning Ruby <http://rubylearning.com/satishtalim/tutorial.html>`_
-#. `Official FAQ <https://www.ruby-lang.org/en/documentation/faq/>`_
-
-
-**GCC:**
-
-GCC stands for GNU Compiler Collection, and GNU is a Unix-Like operating system 
-that allocates resources and communicates with hardware. GNU is often used with 
-a kernel called Linux. The Compiler Collection is one element that allows for 
-PyNE to work as a Python library, even though it is built with several languages.
-
-``To Install:``
-
-`Installing GCC <https://gcc.gnu.org/install/index.html>`_
-
-Homebrew Install:
-
-If you have homebrew installed on your device, you can install GCC by entering ::
-
-	$ brew install gcc
-
-``Resources:``
-
-#. `Documentation <https://gcc.gnu.org/onlinedocs/gfortran/#toc-Compiler-Characteristics-1>`_
-#. `GCC FAQ <https://gcc.gnu.org/wiki/FAQ>`_
-#. `GCC Glossary <https://gcc.gnu.org/wiki/GCC_glossary>`_
-
-
-**CMake:**
-
-CMake is designed to build, test, and compile packages programs across platforms.
-
-``To Install:``
-
-To download CMake, you can visit `Downloads <https://cmake.org/download/>`_.
-
-If you have homebrew installed on your device, you can install GCC by entering ::
-
-	$ brew install gcc
-
-``Resources:``
-
-#. `Wiki <https://gitlab.kitware.com/cmake/community/-/wikis/home>`_
-#. `Tutorial <https://cmake.org/cmake/help/latest/guide/tutorial/index.html>`_
-
-
-**Numpy:**
-
-Numpy is a library in Python that adds support to matricies and arrays, 
-as well as mathematical functions acting on those arrays.
-
-``To Install:``
-
-For the latest version using pip, in the command line enter ::
-
-	$ pip install numpy
-
-For the latest version using Conda, in the command line enter ::
-
-	$ conda install numpy
-
-
-``Resources:``
-
-#. `Tutorial <https://numpy.org/learn/>`_
-#. `Documentation <https://numpy.org/doc/stable/>`_
-
-
-**SciPy:**
-
-SciPy is a Python library that adds functions for linear algebra, optimization, 
-integration, and other scientific or engineering tasks.
-
-``To Install:``
-
-`Installation <https://www.scipy.org/install.html>`_
-
-``Resources:``
-
-#. `Getting Started <https://www.scipy.org/getting-started.html>`_
-#. `Tutorial <https://docs.scipy.org/doc/scipy/reference/tutorial/index.html>`_
-#. `Documentation <https://www.scipy.org/docs.html>`_
-
-
-**Cython:**
-
-Cython is a compiler that helps in making C or C++ extensions for python.
-
-``To Install:``
-
-For the latest version, in the command line enter ::
-
-	$ pip install cython
-
-If you have homebrew installed on your device, you can install Cython by entering ::
-
-	$ brew install cython
-
-``Resources:``
-
-#. `Wiki <https://github.com/cython/cython/wiki>`_
-#. `User's Guide <https://cython.readthedocs.io/en/latest/src/userguide/index.html>`_
-#. `Cython <https://cython.org>`_
-
-
-**HDF5:**
-
-HDF5 (the Hierarchical Data Format version 5) is a format that supports large, 
-complex data in a file directory like structure similar to how you might with your computer.
-
-``To Install:``
-
-To install from source code, 
-follow the instructions `here <https://www.hdfgroup.org/downloads/hdf5/source-code/>`_ .
-
-For the latest version, in the command line enter ::
-
-	$ brew install hdf5
-
-``Resources:``
-
-#. `Examples <https://portal.hdfgroup.org/display/HDF5/HDF5+Examples>`_
-#. `Learning HDF5 <https://portal.hdfgroup.org/display/HDF5/Learning+HDF5>`_
-#. `Known Problems <https://portal.hdfgroup.org/display/support/HDF5%201.12.0#knownprob>`_
-
-
-**PyTables:**
-
-PyTables is a package for managing large hierarchical datasets.
-
-``To Install:``
-
-For a variety of installation instructions, 
-follow the instructions `here <http://www.pytables.org/usersguide/installation.html>`_ .
-
-For the latest version, in the command line enter ::
-
-	$ brew install tables
-
-``Resources:``
-
-#. `FAQ <http://www.pytables.org/FAQ.html>`_
-#. `Tutorial <http://www.pytables.org/usersguide/tutorials.html>`_
-#. `Project Pointers <http://www.pytables.org/project_pointers.html>`_
-
-
-**LAPACK:**
-
-LAPACK (Liner Algebra Package) is a software library for numerical liner algebra.
-
-``To Install:``
-
-Other installation methods can be found `here <http://www.netlib.org/lapack/#_software>`_
-
-For the latest version, in the command line enter ::
-
-	$ brew install lapack
-
-``Resources:``
-
-#. `FAQ <http://www.netlib.org/lapack/faq.html>`_
-#. `User's Guide <http://www.netlib.org/lapack/lug/>`_
-
-
-**BLAS:**
-
-BLAS (Basic Linear Algebra Subroutines) coordinates operations on vectors and matricies.
-
-``To Install:``
-
-Other installation methods can be found `here <http://www.netlib.org/blas/#_software>`_
-
-For the latest version, in the command line enter ::
-
-	$ brew install openblas
-
-``Resources:``
-
-#. `Documentation <http://www.netlib.org/blas/#_documentation>`_
-
-
-**Numexpr:**
-
-Numexpr is a fast numerical evaluation tool for numpy, ensuring that 
-expressions operating on arrays are faster and take up less memory.
-
-``To Install:``
-
-For the latest version, in the command line enter ::
-
-	$ pip install numexpr
-
-``Resources:``
-
-#. `PyPi Project Homepage <https://pypi.org/project/numexpr/>`_
-#. `Github Repository <https://github.com/pydata/numexpr>`_
-
-
--------
-Website
--------
-
-**Sphinx:** 
-
-A python based documentation generator that allows files to be written into HTML, LaTeX, 
-ePub, Texinfo, pages, and plain text. Sphinx uses reStructuredText, which is a very 
-straight-forward markup language.
-
-``To Install:``
-
-For the latest version, in the command line enter ::
-
-	$ pip install sphinx
-
-``Resources:``
-
-#. `Sphinx <https://www.sphinx-doc.org/en/master/>`_
-#. `Tutorial <http://matplotlib.sourceforge.net/sampledoc/>`_
-#. `reStructuredText Cheat Sheet <https://docutils.sourceforge.io/docs/user/rst/cheatsheet.txt>`_
-
-
-**Sphinxcontrib-bibtex:**
-
-An extension allowing Sphinx to interact with BibTeX.
-
-``To Install:``
-
-For the latest version, in the command line enter ::
-
-	$ pip install sphinxcontrib-bibtex
-
-``Resources:``
-
-#. `Documentation <https://sphinxcontrib-bibtex.readthedocs.io/en/latest/>`_ 
-#. `Known Issues and Workarounds <https://sphinxcontrib-bibtex.readthedocs.io/en/latest/usage.html#known-issues-and-workarounds>`_
-#. `Example <https://sphinxcontrib-bibtex.readthedocs.io/en/latest/quickstart.html#minimal-example>`_
-
-
-**PrettyTable:**
-
-PrettyTable is a python library that adds a lot of versatility to table creation.
-
-``To Install:``
-
-For the latest version, in the command line enter ::
-
-	$ pip install prettytable
-
-``Resources:``
-
-#. `Tutorial <https://code.google.com/archive/p/prettytable/wikis/Tutorial.wiki>`_
-
-
-**Cloud Sphinx:**
-
-Cloud is a Sphinx theme that PyNE uses to generate its 
-HTML documentation (like this site).
-
-``To Install:``
-
-For the latest version, in the command line enter ::
-
-	$ pip install cloud_sptheme
-
-``Resources:``
-
-#. `Documentation <https://cloud-sptheme.readthedocs.io/en/latest/>`_
-#. `Source <https://foss.heptapod.net/doc-utils/cloud_sptheme>`_
-
-
-**Jupyter:**
-
-If you have downloaded Python through Anaconda Jupyter requirements should 
-be satasfied, but it never hurts to make sure. 
-
-You can check there version by entering ::
-
-	$jupyter —-version
-
-``To Install:``
-
-If you are going to use Python 2:
-
-For the latest version, in the command line enter ::
-
-	$ pip install jupyter
-
-If you are going to use Python 3:
-
-For the latest version, in the command line enter ::
-
-	$ pip3 install jupyter
-
-``Resources:``
-
-#. `Additional Installation Information <https://jupyter.readthedocs.io/en/latest/install.html>`_
-#. `Project Documentation <https://jupyter.readthedocs.io/en/latest/projects/doc-proj-categories.html#deployment>`_

--- a/docs/devsguide/windowsdep.rst
+++ b/docs/devsguide/windowsdep.rst
@@ -1,0 +1,391 @@
+.. _windowsdep:
+
+=============================
+Windows Dependencies for PyNE
+=============================
+
+Something to note before you begin the installation process is the version of Python 
+that you are using. PyNE is currently supported from Python 2 through Python 3.6 
+(NOT 3.7, which is coming in future updates).
+
+
+-------------
+PyNE Library:
+-------------
+
+PyNE is what is known as a library in Python (as with many languages, 
+libraries can be built and installed to add functionalities to the language), 
+and it is designed to assist in Nuclear Engineering projects. 
+
+
+Python
+''''''
+
+Python is a popular computer language for building applications, 
+data science, and visualization. 
+
+``To Install:``
+
+Anaconda is a comprehensive Python package 
+which provides a free installation for MacOS, Windows, and Linux. Follow the instructions 
+for your device's platform `here <https://docs.anaconda.com/anaconda/install/>`_ if you would 
+like to use Anaconda. Installing Python through Anaconda will result in many of the packages and 
+dependencies for PyNE being satisfied.
+
+If you want to download Python without the rest of Anaconda, use 
+the links in the resources below. Keep in-mind that PyNE is currently 
+not supported on Python 3.7 or later, but you can follow the instructions
+for Anaconda users in the New Developer's Guide.
+
+``Resources:``
+
+#. `Python Download (Not Anaconda) <https://www.python.org/downloads/>`_
+#. `Python Wiki <https://wiki.python.org/moin/>`_
+#. `Beginner’s Guide <https://wiki.python.org/moin/BeginnersGuide>`_
+
+
+GCC
+'''
+
+GCC stands for GNU Compiler Collection, and GNU is a Unix-Like operating system 
+that allocates resources and communicates with hardware. GNU is often used with 
+a kernel called Linux. The Compiler Collection is one element that allows for 
+PyNE to work as a Python library, even though it is built with several languages.
+
+``To Install:``
+
+To download GCC, visit `Installing GCC <https://gcc.gnu.org/install/index.html>`_
+
+``Resources:``
+
+#. `Documentation <https://gcc.gnu.org/onlinedocs/gfortran/#toc-Compiler-Characteristics-1>`_
+#. `GCC FAQ <https://gcc.gnu.org/wiki/FAQ>`_
+#. `GCC Glossary <https://gcc.gnu.org/wiki/GCC_glossary>`_
+
+
+CMake
+'''''
+
+CMake is designed to build, test, and compile packages programs across platforms.
+
+``To Install:``
+
+To download CMake, you can visit `Downloads <https://cmake.org/download/>`_.
+
+``Resources:``
+
+#. `Wiki <https://gitlab.kitware.com/cmake/community/-/wikis/home>`_
+#. `Tutorial <https://cmake.org/cmake/help/latest/guide/tutorial/index.html>`_
+
+
+Numpy
+'''''
+
+Numpy is a library in Python that adds support to matrices and arrays, 
+as well as mathematical functions acting on those arrays.
+
+``To Install:``
+
+First, install PIP 
+
+#. Download this file `get-pip.py <https://bootstrap.pypa.io/get-pip.py>`_
+
+#. Launch your Command Prompt window
+	A. Press Windows Key + X
+	B. Click Run
+	C. Type in cmd.exe and hit enter
+
+#. ‘cd’ to the folder with get-pip.py in it
+
+#. enter ::
+
+    $ python get-pip.py
+
+For more details, go `here <https://phoenixnap.com/kb/install-pip-windows>`_
+
+
+Then use PIP to install Numpy ::
+
+	$ pip3 install numpy
+
+For more details, go `here <https://phoenixnap.com/kb/install-numpy>`_ 
+
+``Resources:``
+
+#. `Tutorial <https://numpy.org/learn/>`_
+#. `Documentation <https://numpy.org/doc/stable/>`_
+
+
+SciPy
+'''''
+
+SciPy is a Python library that adds functions for linear algebra, optimization, 
+integration, and other scientific or engineering tasks.
+
+``To Install:``
+
+To use PIP to install SciPy::
+
+	$ pip install scipy
+
+For more details, go `here <https://www.scipy.org/install.html>`_
+
+``Resources:``
+
+#. `Getting Started <https://www.scipy.org/getting-started.html>`_
+#. `Tutorial <https://docs.scipy.org/doc/scipy/reference/tutorial/index.html>`_
+#. `Documentation <https://www.scipy.org/docs.html>`_
+
+
+Cython
+''''''
+
+Cython is a compiler that helps in making C or C++ extensions for python.
+
+``To Install:``
+
+To download the newest release of Cython, visit https://cython.org/. 
+Then unpack the file, enter the directory, and run::
+	
+	$ python setup.py install
+
+To use PIP to install Cython::
+
+	$ pip install Cython
+
+For more details, go `here <https://cython.readthedocs.io/en/latest/src/quickstart/install.html>`_ .
+
+For a list of Windows installers, go `here <https://www.lfd.uci.edu/~gohlke/pythonlibs/#cython>`_ .
+
+``Resources:``
+
+#. `Wiki <https://github.com/cython/cython/wiki>`_
+#. `User's Guide <https://cython.readthedocs.io/en/latest/src/userguide/index.html>`_
+#. `Cython <https://cython.org>`_
+
+
+HDF5
+''''
+
+HDF5 (the Hierarchical Data Format version 5) is a format that supports large, 
+complex data in a file directory like structure similar to how you might with your computer.
+
+``To Install:``
+
+Follow the instructions 
+`here <https://support.hdfgroup.org/HDF5/faq/windows.html#:~:text=Download%20the%20HDF5%20pre%2Dcompiled,HDF5%20libraries%20and%20include%20files.>`_ 
+to install HDF5.
+
+To install from source code, 
+follow the instructions `here <https://www.hdfgroup.org/downloads/hdf5/source-code/>`_ .
+
+``Resources:``
+
+#. `Examples <https://portal.hdfgroup.org/display/HDF5/HDF5+Examples>`_
+#. `Learning HDF5 <https://portal.hdfgroup.org/display/HDF5/Learning+HDF5>`_
+#. `Known Problems <https://portal.hdfgroup.org/display/support/HDF5%201.12.0#knownprob>`_
+
+
+PyTables
+''''''''
+
+PyTables is a package for managing large hierarchical datasets.
+
+``To Install:``
+
+For a variety of installation instructions, 
+follow the instructions `here <http://www.pytables.org/usersguide/installation.html>`_ .
+
+``Resources:``
+
+#. `FAQ <http://www.pytables.org/FAQ.html>`_
+#. `Tutorial <http://www.pytables.org/usersguide/tutorials.html>`_
+#. `Project Pointers <http://www.pytables.org/project_pointers.html>`_
+
+
+BLAS
+''''
+
+BLAS (Basic Linear Algebra Subroutines) coordinates operations on vectors and .
+
+``To Install:``
+
+Follow the instruction methods `here <http://icl.cs.utk.edu/lapack-for-windows/lapack/>`_ 
+to install BLAS.
+
+Installation methods can be found `here <http://www.netlib.org/blas/#_software>`_ .
+
+``Resources:``
+
+#. `Documentation <http://www.netlib.org/blas/#_documentation>`_
+
+
+LAPACK
+''''''
+
+LAPACK (Liner Algebra Package) is a software library for numerical liner algebra.
+
+``To Install:``
+
+Follow the instruction methods `here <https://icl.cs.utk.edu/lapack-for-windows/lapack/#libraries_intel>`_ 
+to install LAPACK.
+
+Installation methods can be found `here <http://www.netlib.org/blas/#_software>`_ .
+
+``Resources:``
+
+#. `FAQ <http://www.netlib.org/lapack/faq.html>`_
+#. `User's Guide <http://www.netlib.org/lapack/lug/>`_
+
+
+Numexpr
+'''''''
+
+Numexpr is a fast numerical evaluation tool for numpy, ensuring that 
+expressions operating on arrays are faster and take up less memory.
+
+``To Install:``
+
+Based off of instructions found `here <https://numexpr.readthedocs.io/projects/NumExpr3/en/latest/user_guide.html>`_
+, do the following:
+
+#. Download `numexpr <https://github.com/pydata/numexpr>`_
+
+#. Enter the directory where numexpr is located, and run ::
+
+    $ python setup.py build
+    $ python setup.py install
+
+#. Then, enter a different directory and test numexpr ::
+
+    $ python -c "import numexpr; numexpr.test()"
+
+``Resources:``
+
+#. `PyPi Project Homepage <https://pypi.org/project/numexpr/>`_
+#. `Github Repository <https://github.com/pydata/numexpr>`_
+
+
+--------
+Website:
+--------
+
+Sphinx
+''''''
+
+A python based documentation generator that allows files to be written into HTML, LaTeX, 
+ePub, Texinfo, pages, and plain text. Sphinx uses reStructuredText, which is a very 
+straight-forward markup language.
+
+``To Install:``
+
+Either `install from source <https://www.sphinx-doc.org/en/master/usage/installation.html#installation-from-source>`_ 
+, or `install with pip <https://www.sphinx-doc.org/en/master/usage/installation.html#install-pypi>`_ .
+
+To install from the `github source <https://github.com/sphinx-doc/sphinx>`_ ::
+
+#. Clone the Sphinx repository ::
+
+    $ git clone https://github.com/sphinx-doc/sphinx
+
+#. Enter the clone
+
+#. Enter ::
+
+    $ pip install .
+    $ pip install git+https://github.com/sphinx-doc/sphinx
+
+To install with pip:
+
+#. Open Command Prompt and enter ::
+
+    C:\> pip install -U sphinx
+
+``Resources:``
+
+#. `Sphinx <https://www.sphinx-doc.org/en/master/>`_
+#. `Tutorial <http://matplotlib.sourceforge.net/sampledoc/>`_
+#. `reStructuredText Cheat Sheet <https://docutils.sourceforge.io/docs/user/rst/cheatsheet.txt>`_
+
+
+Sphinxcontrib-bibtex
+''''''''''''''''''''
+
+An extension allowing Sphinx to interact with BibTeX.
+
+``To Install:``
+
+#. Download the Sphinxcontrib-bibtex from `source <https://github.com/mcmtroffaes/sphinxcontrib-bibtex>`_ .
+
+#. Un-zip the file (if necessary) and, in the command prompt, "cd" into the folder.
+
+#. Enter ::
+
+    python setup.py install
+
+
+For more details about installing on windows with a setup.py file, go 
+`here <https://docs.python.org/2/install/#standard-build-and-install>`_ .
+
+``Resources:``
+
+#. `Documentation <https://sphinxcontrib-bibtex.readthedocs.io/en/latest/>`_ 
+#. `Known Issues and Workarounds <https://sphinxcontrib-bibtex.readthedocs.io/en/latest/usage.html#known-issues-and-workarounds>`_
+#. `Example <https://sphinxcontrib-bibtex.readthedocs.io/en/latest/quickstart.html#minimal-example>`_
+
+
+PrettyTable
+'''''''''''
+
+PrettyTable is a python library that adds a lot of versatility to table creation.
+
+``To Install:``
+
+Visit the `Installation Wiki <https://code.google.com/archive/p/prettytable/wikis/Installation.wiki>`_ for instructions on how to 
+install PrettyTable. 
+
+``Resources:``
+
+#. `Tutorial <https://code.google.com/archive/p/prettytable/wikis/Tutorial.wiki>`_
+
+
+Cloud Sphinx
+''''''''''''
+
+Cloud is a Sphinx theme that PyNE uses to generate its 
+HTML documentation (like this site).
+
+``To Install:``
+
+#. Download the `source code <https://foss.heptapod.net/doc-utils/cloud_sptheme/-/tree/branch/default>`_ .
+
+#. Un-zip the file (if necessary) and, in the command prompt, "cd" into the folder.
+
+#. Enter ::
+
+    $ python setup.py install
+
+For more details about installing on windows with a setup.py file, go 
+`here <https://docs.python.org/2/install/#standard-build-and-install>`_ .
+
+``Resources:``
+
+#. `Documentation <https://cloud-sptheme.readthedocs.io/en/latest/>`_
+#. `Source <https://foss.heptapod.net/doc-utils/cloud_sptheme>`_
+
+
+Jupyter
+'''''''
+
+If you have downloaded Python through Anaconda Jupyter requirements should 
+be satisfied, but it never hurts to make sure. 
+
+
+``To Install:``
+
+To download Jupyter Notebook, visit `Installing Jupyter-Notebook <https://jupyter.readthedocs.io/en/latest/install.html>`_ .
+
+``Resources:``
+
+#. `Additional Installation Information <https://jupyter.readthedocs.io/en/latest/install.html>`_
+#. `Project Documentation <https://jupyter.readthedocs.io/en/latest/projects/doc-proj-categories.html#deployment>`_


### PR DESCRIPTION
This PR, merges the three additional documents (for MacOS, Linux, and Windows) that detail how to install the dependencies for PyNE. It also updates the new_dev_guide so that these documents are linked there, and removes the dependencies that were formerly on that page.